### PR TITLE
Modify main page by reducing SearchResultItem types

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,12 +9,7 @@ import MockProfiles from "../mocks/MockProfiles";
 
 interface SearchResultItem {
   title: string;
-  link: string;
-  category: string;
-  description: string;
-  telephone: string;
   address: string;
-  roadAddress: string;
   location: LatLng;
 }
 interface LatLng {


### PR DESCRIPTION
메인 페이지 
-  타입 정리 (추후에 필요한 타입들은 타입 확정 후 추가될 예정)
```
interface SearchResultItem {
  title: string;
  address: string;
  location: LatLng;
}
interface LatLng {
  lat: number;
  lng: number;
}
```